### PR TITLE
Use single quotes for strings in SQL queries to be ANSI-compliant

### DIFF
--- a/application/core/MY_Model.php
+++ b/application/core/MY_Model.php
@@ -5,11 +5,11 @@ if( ! class_exists('CRUD_Model')) {
 
 class MY_Model extends CRUD_Model {
     protected $virtual_fields = array(
-        'depth' => 'LENGTH(units.`path`) - (LENGTH(REPLACE(units.`path`, "/", "")))',
-        'parent_id' => 'NULLIF(SUBSTRING_INDEX(SUBSTRING_INDEX(units.`path`, "/", -2), "/", 1), "")',
-        'unit_key' => 'REPLACE(REPLACE(REPLACE(REPLACE(units.`abbr`, " HQ", ""), " Co", ""), ".", ""), " ", "")',
-        'short_name' => 'CONCAT(ranks.`abbr`, " ", IF(members.`name_prefix` != "", CONCAT(members.`name_prefix`, ". "), ""), members.`last_name`)',
-        'full_name' => 'CONCAT(members.`first_name`, " ", IF(members.`middle_name` != "", CONCAT(LEFT(members.`middle_name`, 1), ". "), ""), members.`last_name`)',
+        'depth' => "LENGTH(units.`path`) - (LENGTH(REPLACE(units.`path`, '/', '')))",
+        'parent_id' => "NULLIF(SUBSTRING_INDEX(SUBSTRING_INDEX(units.`path`, '/', -2), '/', 1), '')",
+        'unit_key' => "REPLACE(REPLACE(REPLACE(REPLACE(units.`abbr`, ' HQ', ''), ' Co', ''), '.', ''), ' ', '')",
+        'short_name' => "CONCAT(ranks.`abbr`, ' ', IF(members.`name_prefix` != '', CONCAT(members.`name_prefix`, '. '), ''), members.`last_name`)",
+        'full_name' => "CONCAT(members.`first_name`, ' ', IF(members.`middle_name` != '', CONCAT(LEFT(members.`middle_name`, 1), '. '), ''), members.`last_name`)",
     );
     
     public function select_member($join_type = 'left') {
@@ -30,9 +30,9 @@ class MY_Model extends CRUD_Model {
         $this->filter_join('units', 'units.id = assignments.unit_id');
 
         if(is_numeric($unit_id)) {
-            $this->filter_where('(units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")');
+            $this->filter_where('(units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')");
         } elseif($lookup = $this->getByUnitKey($unit_id)) {
-            $this->filter_where('(units.id = ' . $lookup['id'] . ' OR (units.path LIKE "%/' . $lookup['id'] . '/%"))');
+            $this->filter_where('(units.id = ' . $lookup['id'] . " OR (units.path LIKE '%/" . $lookup['id'] . "/%'))");
         }
         $this->filter_where('assignments.end_date IS NULL'); // Only include current members
         $this->filter_group_by($this->primary_key);
@@ -55,9 +55,9 @@ class MY_Model extends CRUD_Model {
         $this->filter_join('units', 'units.id = assignments.unit_id');
 */
         if(is_numeric($unit_id)) {
-            $_where_clause .= ' AND (units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")';
+            $_where_clause .= ' AND (units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')";
         } elseif($lookup = $this->getByUnitKey($unit_id)) {
-            $_where_clause .= ' AND (units.id = ' . $lookup['id'] . ' OR (units.path LIKE "%/' . $lookup['id'] . '/%"))';
+            $_where_clause .= ' AND (units.id = ' . $lookup['id'] . " OR (units.path LIKE '%/" . $lookup['id'] . "/%'))";
         }
 /*
         $this->filter_where('assignments.end_date IS NULL'); // Only include current members

--- a/application/libraries/User.php
+++ b/application/libraries/User.php
@@ -88,7 +88,7 @@ class User {
     public function authenticate($user_id, $password) {
         return true; // DEBUG
         $forums_db = $this->load->database('forums', TRUE);
-        $query = $forums_db->query('SELECT id_member FROM smf_members WHERE id_member = ' . $user_id . ' AND SHA1(CONCAT(passwd, password_salt)) = "' . $password . '"');
+        $query = $forums_db->query('SELECT id_member FROM smf_members WHERE id_member = ' . $user_id . " AND SHA1(CONCAT(passwd, password_salt)) = '" . $password . "'");
         $num_rows = $query->num_rows();
         $forums_db->close();
         return $num_rows ? true : false;

--- a/application/models/alerts_model.php
+++ b/application/models/alerts_model.php
@@ -22,7 +22,7 @@ class Alerts_model extends MY_Model {
         $this->filter_join('(SELECT member_id, GROUP_CONCAT(date) AS aocc_list FROM awardings WHERE awardings.award_id = 10 GROUP BY awardings.member_id) AS aocc_awardings', 'aocc_awardings.member_id = members.id', 'left');
         $this->filter_join('(SELECT member_id, GROUP_CONCAT(date) AS ww1v_list FROM awardings WHERE awardings.award_id = 61 GROUP BY awardings.member_id) AS ww1v_awardings', 'ww1v_awardings.member_id = members.id', 'left');
         $this->filter_join('(SELECT member_id, Max(award_id)-27 AS cab_lvl FROM awardings WHERE awardings.award_id IN (28,29,30,31,32) GROUP BY awardings.member_id) AS cabs_awardings', 'cabs_awardings.member_id = members.id', 'left');
-        $this->filter_join('(SELECT e.recruiter_member_id AS id, Count(1) as rec_cnt, Max(e.date) AS last_enl_date FROM enlistments AS e LEFT JOIN units AS ue ON ue.id=e.unit_id WHERE e.status="Accepted" AND e.recruiter_member_id IS NOT NULL AND (ue.active=0 OR ue.class<>"Training" OR e.unit_id IS NULL) GROUP BY e.recruiter_member_id) AS recuits', 'recuits.id = members.id', 'left');
+        $this->filter_join("(SELECT e.recruiter_member_id AS id, Count(1) as rec_cnt, Max(e.date) AS last_enl_date FROM enlistments AS e LEFT JOIN units AS ue ON ue.id=e.unit_id WHERE e.status='Accepted' AND e.recruiter_member_id IS NOT NULL AND (ue.active=0 OR ue.class<>'Training' OR e.unit_id IS NULL) GROUP BY e.recruiter_member_id) AS recuits", 'recuits.id = members.id', 'left');
     }
 
     public function default_order_by($member_id = FALSE) {

--- a/application/models/assignment_model.php
+++ b/application/models/assignment_model.php
@@ -131,8 +131,8 @@ class Assignment_model extends MY_Model {
      */
     public function by_date($date = 'now') {
         $date = format_date($date, 'mysqldate'); // Format date string for MySQL
-        $this->filter_where('(assignments.start_date <= "' . $date . '")');
-        $this->filter_where('(assignments.end_date > "' . $date . '" OR assignments.end_date IS NULL)');
+        $this->filter_where("(assignments.start_date <= '" . $date . "')");
+        $this->filter_where("(assignments.end_date > '" . $date . "' OR assignments.end_date IS NULL)");
         return $this;
     }
     
@@ -158,7 +158,7 @@ class Assignment_model extends MY_Model {
         
         // If seeking members of child units, look for $unit_id in path or id
         if($children !== FALSE) {
-            $this->filter_where('(assignments.unit_id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")');
+            $this->filter_where('(assignments.unit_id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')");
         } else {
             $this->filter_where('assignments.unit_id', $unit_id);
         }
@@ -214,7 +214,7 @@ class Assignment_model extends MY_Model {
     public function discharge($member_id, $date = 'now') {
         $date = format_date($date, 'mysqldate'); // Format date string for MySQL
         $this->db->where('assignments.member_id', $member_id)
-            ->where('(assignments.end_date IS NULL OR assignments.end_date > "' . $date . '")', NULL, FALSE)
+            ->where("(assignments.end_date IS NULL OR assignments.end_date > '" . $date . "')", NULL, FALSE)
             ->update($this->table, array('assignments.end_date' => $date));
     }
 }

--- a/application/models/attendance_model.php
+++ b/application/models/attendance_model.php
@@ -45,12 +45,12 @@ class Attendance_model extends MY_Model {
         $this->filter_select('SUM(attendance.attended) AS attended, COUNT(attendance.attended) - SUM(attendance.attended) AS absent, SUM(IF(attendance.attended = 0, IF(attendance.excused = 1, 1, 0), 0)) AS excused, IF(events.reporter_member_id IS NULL, 0, 1) as is_aar ', FALSE);
 
         if(is_numeric($unit_id)) {
-            $this->filter_where('(units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")');
+            $this->filter_where('(units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')");
         } elseif($lookup = $this->getByUnitKey($unit_id)) {
-            $this->filter_where('(units.id = ' . $lookup['id'] . ' OR (units.path LIKE "%/' . $lookup['id'] . '/%"))');
+            $this->filter_where('(units.id = ' . $lookup['id'] . " OR (units.path LIKE '%/" . $lookup['id'] . "/%'))");
         }
 
-        $this->filter_where('(events.reporter_member_id IS NOT NULL OR units.class="Training")');
+        $this->filter_where("(events.reporter_member_id IS NOT NULL OR units.class='Training')");
         $this->filter_group_by('attendance.event_id');
         $this->filter_order_by('events.datetime DESC');
         return $this;
@@ -107,8 +107,8 @@ class Attendance_model extends MY_Model {
         $this->filter_where('events.datetime >= DATE_SUB(NOW(), INTERVAL ' . (int) $days . ' DAY)');
         $this->filter_where('events.datetime < DATE_SUB(NOW(), INTERVAL 24 HOUR)'); // Not considered AWOL until 24 hours after the event
         $this->filter_where('events.mandatory', 1);
-        $this->filter_where('(units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")');
-        $this->filter_where('(assignmentUnits.id = ' . $unit_id . ' OR assignmentUnits.path LIKE "%/' . $unit_id . '/%")');
+        $this->filter_where('(units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')");
+        $this->filter_where('(assignmentUnits.id = ' . $unit_id . " OR assignmentUnits.path LIKE '%/" . $unit_id . "/%')");
         $this->filter_where('assignments.end_date IS NULL'); // Only include current members
         $this->filter_order_by('events.datetime');
         //$this->filter_group_by('`member|id`, `event|date`'); // Add this to limit AWOLs to one per day
@@ -155,9 +155,9 @@ class Attendance_model extends MY_Model {
         
         if ( $filter_key == 'unit' ) {
              if(is_numeric($filter_value)) {
-                 $cSql .= 'AND (e.unit_id = ' . (int) $filter_value . ' OR u.path LIKE "%/' . (int) $filter_value . '/%")';
+                 $cSql .= 'AND (e.unit_id = ' . (int) $filter_value . " OR u.path LIKE '%/" . (int) $filter_value . "/%')";
              } elseif($lookup = $this->getByUnitKey($filter_value)) {
-                 $cSql .= 'AND (e.unit_id = ' . $lookup['id'] . ' OR (u.path LIKE "%/' . $lookup['id'] . '/%"))';
+                 $cSql .= 'AND (e.unit_id = ' . $lookup['id'] . " OR (u.path LIKE '%/" . $lookup['id'] . "/%'))";
              }
         }
         else {

--- a/application/models/banlog_model.php
+++ b/application/models/banlog_model.php
@@ -36,7 +36,7 @@ class Banlog_model extends MY_Model {
         $this->filter_select('banlog.id_admin AS `admin|id`');
         $this->filter_select($this->virtual_fields['short_name'] . ' AS `admin|short_name`', FALSE);
         $this->filter_select('banlog.id_poster AS `poster|id`');
-        $this->filter_select('CONCAT(p_ranks.abbr," ",p_members.last_name) AS `poster|short_name`', FALSE);
+        $this->filter_select("CONCAT(p_ranks.abbr,' ',p_members.last_name) AS `poster|short_name`", FALSE);
         $this->filter_join('members', 'members.id = banlog.id_admin','left');
         $this->filter_join('ranks', 'ranks.id = members.rank_id','left');
         $this->filter_join('members AS p_members', 'p_members.id = banlog.id_poster','left');

--- a/application/models/demerit_model.php
+++ b/application/models/demerit_model.php
@@ -39,7 +39,7 @@ class Demerit_model extends MY_Model {
             
             // Author
             ->select('demerits.author_member_id AS `author|id`')
-            ->select('CONCAT(a_ranks.`abbr`, " ", IF(a_members.`name_prefix` != "", CONCAT(a_members.`name_prefix`, " "), ""), a_members.`last_name`) AS `author|short_name`', FALSE);
+            ->select("CONCAT(a_ranks.`abbr`, ' ', IF(a_members.`name_prefix` != '', CONCAT(a_members.`name_prefix`, ' '), ''), a_members.`last_name`) AS `author|short_name`", FALSE);
     }
     
     public function default_join() {

--- a/application/models/discharge_model.php
+++ b/application/models/discharge_model.php
@@ -82,9 +82,9 @@ class Discharge_model extends MY_Model {
         $this->filter_join('units', 'units.id = assignments.unit_id');
 
         if(is_numeric($unit_id)) {
-            $this->filter_where('(units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")');
+            $this->filter_where('(units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')");
         } elseif($lookup = $this->getByUnitKey($unit_id)) {
-            $this->filter_where('(units.id = ' . $lookup['id'] . ' OR (units.path LIKE "%/' . $lookup['id'] . '/%"))');
+            $this->filter_where('(units.id = ' . $lookup['id'] . " OR (units.path LIKE '%/" . $lookup['id'] . "/%'))");
         }
         $this->filter_group_by($this->primary_key);
         return $this;

--- a/application/models/enlistment_model.php
+++ b/application/models/enlistment_model.php
@@ -141,7 +141,7 @@ class Enlistment_model extends MY_Model {
             ->select('members.rank_id AS `member|rank_id`')
             ->select('members.forum_member_id AS `member|forum_member_id`')
             ->select('enlistments.liaison_member_id AS `liaison|id`')
-            ->select('CONCAT(l_ranks.`abbr`, " ", IF(l_members.`name_prefix` != "", CONCAT(l_members.`name_prefix`, ". "), ""), l_members.`last_name`) AS `liaison|short_name`', FALSE)
+            ->select("CONCAT(l_ranks.`abbr`, ' ', IF(l_members.`name_prefix` != '', CONCAT(l_members.`name_prefix`, '. '), ''), l_members.`last_name`) AS `liaison|short_name`", FALSE)
             ->select('enlistments.country_id AS `country|id`, countries.name AS `country|name`, countries.abbr AS `country|abbr`');
     }
     

--- a/application/models/event_model.php
+++ b/application/models/event_model.php
@@ -108,9 +108,9 @@ class Event_model extends MY_Model {
 
     public function by_unit($unit_id) {
         if(is_numeric($unit_id)) {
-            $this->filter_where('(units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")');
+            $this->filter_where('(units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')");
         } elseif($lookup = $this->getByUnitKey($unit_id)) {
-            $this->filter_where('(units.id = ' . $lookup['id'] . ' OR (units.path LIKE "%/' . $lookup['id'] . '/%"))');
+            $this->filter_where('(units.id = ' . $lookup['id'] . " OR (units.path LIKE '%/" . $lookup['id'] . "/%'))");
         }
         $this->filter_group_by($this->primary_key);
         return $this;

--- a/application/models/note_model.php
+++ b/application/models/note_model.php
@@ -16,9 +16,9 @@ class Note_model extends MY_Model {
     public function default_select() {
         $this->db->select('SQL_CALC_FOUND_ROWS notes.*', FALSE)
             ->select('authors.id AS `author|id`', FALSE)
-            ->select('CONCAT(a_ranks.`abbr`, " ", IF(authors.`name_prefix` != "", CONCAT(authors.`name_prefix`, " "), ""), authors.`last_name`) AS `author|short_name`', FALSE)
+            ->select("CONCAT(a_ranks.`abbr`, ' ', IF(authors.`name_prefix` != '', CONCAT(authors.`name_prefix`, ' '), ''), authors.`last_name`) AS `author|short_name`", FALSE)
             ->select('subjects.id AS `object|id`',FALSE)
-            ->select('CONCAT(s_ranks.`abbr`, " ", IF(subjects.`name_prefix` != "", CONCAT(subjects.`name_prefix`, " "), ""), subjects.`last_name`) AS `object|short_name`', FALSE)
+            ->select("CONCAT(s_ranks.`abbr`, ' ', IF(subjects.`name_prefix` != '', CONCAT(subjects.`name_prefix`, ' '), ''), subjects.`last_name`) AS `object|short_name`", FALSE)
         ;
     }
 

--- a/application/models/pass_model.php
+++ b/application/models/pass_model.php
@@ -47,11 +47,11 @@ class Pass_model extends MY_Model {
 
     public function select_member() {
         $this->filter_select('passes.member_id AS `member|id`');
-        $this->filter_select('CONCAT(ranks.abbr," ",members.last_name) AS `member|short_name`', FALSE);
+        $this->filter_select("CONCAT(ranks.abbr,' ',members.last_name) AS `member|short_name`", FALSE);
         $this->filter_select('passes.author_id AS `author|id`');
-        $this->filter_select('CONCAT(a_ranks.abbr," ",a_members.last_name) AS `poster|short_name`', FALSE);
+        $this->filter_select("CONCAT(a_ranks.abbr,' ',a_members.last_name) AS `poster|short_name`", FALSE);
         $this->filter_select('passes.recruit_id AS `recruit|id`');
-        $this->filter_select('CONCAT(r_ranks.abbr," ",r_members.last_name) AS `recruit|short_name`', FALSE);
+        $this->filter_select("CONCAT(r_ranks.abbr,' ',r_members.last_name) AS `recruit|short_name`", FALSE);
         $this->filter_join('members', 'members.id = passes.member_id','left');
         $this->filter_join('ranks', 'ranks.id = members.rank_id','left');
         $this->filter_join('members AS a_members', 'a_members.id = passes.author_id','left');

--- a/application/models/qualification_model.php
+++ b/application/models/qualification_model.php
@@ -33,7 +33,7 @@ class Qualification_model extends MY_Model {
     public function default_select() {
         $this->db->select('qualifications.id, qualifications.date')
             ->select('qualifications.author_member_id AS `author|id`')
-            ->select('CONCAT(a_ranks.`abbr`, " ", IF(a_members.`name_prefix` != "", CONCAT(a_members.`name_prefix`, " "), ""), a_members.`last_name`) AS `author|short_name`', FALSE)
+            ->select("CONCAT(a_ranks.`abbr`, ' ', IF(a_members.`name_prefix` != '', CONCAT(a_members.`name_prefix`, ' '), ''), a_members.`last_name`) AS `author|short_name`", FALSE)
             ->select('qualifications.standard_id AS `standard|id`, s.weapon AS `standard|weapon`, s.badge AS `standard|badge`, s.description AS `standard|description`');
     }
     
@@ -49,16 +49,16 @@ class Qualification_model extends MY_Model {
 
     public function by_unit($unit_id) {
         $this->select('qualifications.member_id AS `member|id`');
-        $this->select('CONCAT(m_ranks.`abbr`, " ", IF(m_members.`name_prefix` != "", CONCAT(m_members.`name_prefix`, " "), ""), m_members.`last_name`) AS `member|short_name`', FALSE);
+        $this->select("CONCAT(m_ranks.`abbr`, ' ', IF(m_members.`name_prefix` != '', CONCAT(m_members.`name_prefix`, ' '), ''), m_members.`last_name`) AS `member|short_name`", FALSE);
         $this->filter_join('assignments', 'assignments.member_id = ' . $this->table . '.member_id', 'left');
         $this->filter_join('units', 'units.id = assignments.unit_id');
         $this->filter_join('members AS m_members', 'm_members.id = qualifications.member_id', 'left');
         $this->filter_join('ranks AS m_ranks', 'm_ranks.id = m_members.rank_id', 'left');
 
         if(is_numeric($unit_id)) {
-            $this->filter_where('(units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%")');
+            $this->filter_where('(units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%')");
         } elseif($lookup = $this->getByUnitKey($unit_id)) {
-            $this->filter_where('(units.id = ' . $lookup['id'] . ' OR (units.path LIKE "%/' . $lookup['id'] . '/%"))');
+            $this->filter_where('(units.id = ' . $lookup['id'] . " OR (units.path LIKE '%/" . $lookup['id'] . "/%'))");
         }
         $this->filter_where('`assignments`.`end_date` IS NULL AND date BETWEEN CURDATE() - INTERVAL 30 DAY AND CURDATE()');
 //        $this->filter_group_by($this->primary_key);

--- a/application/models/recruits_model.php
+++ b/application/models/recruits_model.php
@@ -51,9 +51,9 @@ class Recruits_model extends MY_Model
 
     public function by_unit($unit_id) {
         if(is_numeric($unit_id)) {
-            $this->filter_where('enlistments.recruiter_member_id IN ( SELECT member_id FROM `assignments` WHERE end_date IS NULL AND unit_id IN ( SELECT id FROM `units` WHERE (units.id = ' . $unit_id . ' OR units.path LIKE "%/' . $unit_id . '/%") ) )');
+            $this->filter_where('enlistments.recruiter_member_id IN ( SELECT member_id FROM `assignments` WHERE end_date IS NULL AND unit_id IN ( SELECT id FROM `units` WHERE (units.id = ' . $unit_id . " OR units.path LIKE '%/" . $unit_id . "/%') ) )");
         } elseif($lookup = $this->getByUnitKey($unit_id)) {
-            $this->filter_where('enlistments.recruiter_member_id IN ( SELECT member_id FROM `assignments` WHERE end_date IS NULL AND unit_id IN ( SELECT id FROM `units` WHERE (units.id = ' . $lookup['id'] . ' OR units.path LIKE "%/' . $lookup['id'] . '/%") ) )');
+            $this->filter_where('enlistments.recruiter_member_id IN ( SELECT member_id FROM `assignments` WHERE end_date IS NULL AND unit_id IN ( SELECT id FROM `units` WHERE (units.id = ' . $lookup['id'] . " OR units.path LIKE '%/" . $lookup['id'] . "/%') ) )");
         }
         return $this;
     }

--- a/application/models/tp_model.php
+++ b/application/models/tp_model.php
@@ -19,7 +19,7 @@ class Tp_model extends MY_Model {
     }
     
     public function default_where() {
-        $this->filter_where('units.class = "Training" AND units.id <> 43');
+        $this->filter_where("units.class = 'Training' AND units.id <> 43");
     }
     
     public function default_order_by() {

--- a/application/models/unit_model.php
+++ b/application/models/unit_model.php
@@ -91,7 +91,7 @@ class Unit_model extends MY_Model {
         if(is_numeric($filter)) {
             // If getting children, search by path and id
             if($children !== FALSE) {
-                $this->filter_where('(units.id = ' . $filter . ' OR (' . ( ! $inactive ? 'units.active = 1 AND ' : '') . 'units.path LIKE "%/' . $filter . '/%"))');
+                $this->filter_where('(units.id = ' . $filter . ' OR (' . ( ! $inactive ? 'units.active = 1 AND ' : '') . "units.path LIKE '%/" . $filter . "/%'))");
             }
             // Otherwise just get the individual record by id
             else {
@@ -102,7 +102,7 @@ class Unit_model extends MY_Model {
         else if($filter) {
             // If looking up by unit_key and we want children, we need to get the unit's id with a separate query
             if($children !== FALSE && $lookup = $this->getByUnitKey($filter)) {
-                $this->filter_where('(units.id = ' . $lookup['id'] . ' OR (' . ( ! $inactive ? 'units.active = 1 AND ' : '') . 'units.path LIKE "%/' . $lookup['id'] . '/%"))');
+                $this->filter_where('(units.id = ' . $lookup['id'] . ' OR (' . ( ! $inactive ? 'units.active = 1 AND ' : '') . "units.path LIKE '%/" . $lookup['id'] . "/%'))");
             }
             else {
                 $this->filter_where($this->virtual_fields['unit_key'] . ' = ' . $this->db->escape($filter));


### PR DESCRIPTION
This appears to be a requirement of MySQL v8, which is more strict.