### PR TITLE
Prepare forum integration for discourse switch

### DIFF
--- a/application/controllers/admin.php
+++ b/application/controllers/admin.php
@@ -8,6 +8,7 @@ class Admin extends CI_Controller {
         // Load user library and pass it third-party (forum) cookie
         // Normally done by MY_Controller, but this is not a sub-class of that
         $this->load->library('user', array('cookie' => $this->input->cookie(config_item('third_party_cookie'))));
+        $this->load->library(getenv('FORUMS_LIBRARY_CLASS') ?: 'vanilla', '', 'forums');
         
         if( ! $this->user->permission('admin') && ! $this->user->permission('admin-' . $this->router->method)) {
             die('Permission denied');

--- a/application/controllers/admin.php
+++ b/application/controllers/admin.php
@@ -335,7 +335,7 @@ class Admin extends CI_Controller {
 	
 	public function _callback_members_after_update($data, $id = null) {
         // Update username
-        $this->forums->update_username($id);
+        $this->forums->update_display_name($id);
 	}
 	
 	/**
@@ -402,7 +402,7 @@ class Admin extends CI_Controller {
                 $this->member_model->save($data['member_id'], array('rank_id' => $newest['new_rank']['id']));
             
                 // Update username
-                $this->forums->update_username($data['member_id']);
+                $this->forums->update_display_name($data['member_id']);
                 
                 // Update coat
                 $this->load->library('servicecoat');
@@ -424,7 +424,7 @@ class Admin extends CI_Controller {
                 $this->member_model->save($data['member_id'], array('rank_id' => $newest['new_rank']['id']));
             
                 // Update username
-                $this->forums->update_username($data['member_id']);
+                $this->forums->update_display_name($data['member_id']);
                 
                 // Update coat
                 $this->load->library('servicecoat');

--- a/application/controllers/assignments.php
+++ b/application/controllers/assignments.php
@@ -139,7 +139,7 @@ class Assignments extends MY_Controller {
             
             // Update roles
             $roles = $this->forums->update_roles($data['member_id']);
-            $this->forums->update_username($data['member_id']);
+            $this->forums->update_display_name($data['member_id']);
             
             $this->response(array('status' => $insert_id ? true : false, 'assignment' => $insert_id ? nest($this->assignment_model->select_member()->get_by_id($insert_id)) : null));
         }

--- a/application/controllers/discharges.php
+++ b/application/controllers/discharges.php
@@ -55,7 +55,7 @@ class Discharges extends MY_Controller {
             $insert_id = $this->discharge_model->save(NULL, $data);
 
             // Update username
-            $this->forums->update_username($data['member_id']);
+            $this->forums->update_display_name($data['member_id']);
             
             // Update service coat if not honorable discharge
             if ( $data['type'] <> 'Honorable' )
@@ -93,7 +93,7 @@ class Discharges extends MY_Controller {
             $this->response(array('status' => $result ? true : false, 'discharge' => nest($this->discharge_model->get_by_id($discharge_id))));
 
             // Update username
-            $this->forums->update_username($data['member_id']);
+            $this->forums->update_display_name($data['member_id']);
             // Update service coat
             $this->load->library('servicecoat');
             $this->servicecoat->update($data['member_id']);

--- a/application/controllers/enlistments.php
+++ b/application/controllers/enlistments.php
@@ -263,7 +263,7 @@ class Enlistments extends MY_Controller {
                 }
             }
             // Update username
-            $this->forums->update_username($enlistment['member_id']);
+            $this->forums->update_display_name($enlistment['member_id']);
 
             $this->response(array('status' => false, 'enlistment' => $enlistment));
         }

--- a/application/controllers/members.php
+++ b/application/controllers/members.php
@@ -458,10 +458,11 @@ class Members extends MY_Controller {
         // Execute
         else {
             $this->usertracking->track_this();
-            if($roles = $this->forums->update_roles($member_id)) {
+            try {
+                $roles = $this->forums->update_roles($member_id);
                 $this->response(array('status' => true, 'roles' => $roles));
-            } else {
-                $this->response(array('status' => false, 'error' => 'There was an issue updating the user\'s roles'));
+            } catch (Exception $e) {
+                $this->response(array('status' => false, 'error' => $e->getMessage()));
             }
         }
     }

--- a/application/controllers/members.php
+++ b/application/controllers/members.php
@@ -101,7 +101,7 @@ class Members extends MY_Controller {
             $this->servicecoat->update($member_id);
             
             // Update username
-            $this->forums->update_username($member_id);
+            $this->forums->update_display_name($member_id);
             
             $this->response(array('status' => $result ? true : false, 'member' => $this->member_model->get_by_id($member_id)));
         }

--- a/application/controllers/members.php
+++ b/application/controllers/members.php
@@ -101,7 +101,11 @@ class Members extends MY_Controller {
             $this->servicecoat->update($member_id);
             
             // Update username
-            $this->forums->update_display_name($member_id);
+            try {
+                $this->forums->update_display_name($member_id);
+            } catch (Exception $e) {
+                error_log($e->getMessage());
+            }
             
             $this->response(array('status' => $result ? true : false, 'member' => $this->member_model->get_by_id($member_id)));
         }

--- a/application/controllers/promotions.php
+++ b/application/controllers/promotions.php
@@ -68,7 +68,7 @@ class Promotions extends MY_Controller {
             $this->servicecoat->update($data['member_id']);
             
             // Update username
-            $this->forums->update_username($data['member_id']);
+            $this->forums->update_display_name($data['member_id']);
             $this->forums->update_roles($data['member_id']);
            
             $this->response(array( 'status' => $insert_id ? true : false, 'promotions' => $insert_id ? $this->promotion_model->get_by_id($insert_id) : null));
@@ -108,7 +108,7 @@ class Promotions extends MY_Controller {
             $this->servicecoat->update($member_id);
             
             // Update username
-            $this->forums->update_username($member_id);
+            $this->forums->update_display_name($member_id);
             $this->forums->update_roles($member_id);
             
             $this->response(array('status' => $result ? true : false, 'promotion' => $this->promotion_model->get_by_id($promotion_id)));
@@ -139,7 +139,7 @@ class Promotions extends MY_Controller {
             $this->servicecoat->update($member_id);
             
             // Update username
-            $this->forums->update_username($member_id);
+            $this->forums->update_display_name($member_id);
             $this->forums->update_roles($member_id);
             
             $this->response(array('status' => true));

--- a/application/controllers/users.php
+++ b/application/controllers/users.php
@@ -80,7 +80,7 @@ class Users extends MY_Controller {
                     $result = $this->member_model->save($member['id'], array('forum_member_id' => $user_id));
             
                     // Update username
-                    $this->forums->update_username($member['id']);
+                    $this->forums->update_display_name($member['id']);
                     
                     // Update forum roles
                     if($roles = $this->forums->update_roles($member['id'])) {

--- a/application/libraries/Discourse.php
+++ b/application/libraries/Discourse.php
@@ -1,0 +1,67 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+use GuzzleHttp\Client;
+
+class Discourse {
+  private $client;
+  private $username;
+
+  public function __construct() {
+    $base_uri = getenv('FORUMS_BASE_URL');
+    $api_key = getenv('FORUMS_ACCESS_TOKEN');
+    $api_username = 'system';
+
+    $this->client = new Client([
+      'base_uri' => $base_uri,
+      'headers' => [
+        'Api-Key' => $api_key,
+        'Api-Username' => $api_username
+      ]
+    ]);
+  }
+
+  // Enables the use of CI super-global without having to define an extra variable
+  public function __get($var) {
+      return get_instance()->$var;
+  }
+
+  public function update_display_name($member_id) {
+    $this->load->model('member_model');
+
+    $member = $this->get_member($member_id);
+    $username = $this->get_username($member['forum_member_id']);
+
+    $path = "u/{$username}";
+    $payload = ['name' => $member['short_name']];
+    $response = $this->client->put($path, ['json' => $payload]);
+
+    if ($response->getStatusCode() != 200) {
+      throw new Exception('Failed to update display name');
+    }
+  }
+
+  private function get_member($member_id) {
+    if ($this->member) return $this->member;
+
+    $this->member = nest($this->member_model->get_by_id($member_id));
+    if ( ! $this->member['forum_member_id']) {
+      throw new Exception('Member has no forum_member_id');
+    }
+
+    return $this->member;
+  }
+
+  private function get_username($forum_member_id) {
+    if ($this->username) return $this->username;
+
+    $path = "/admin/users/{$forum_member_id}.json";
+    $response = $this->client->get($path);
+    if ($response->getStatusCode() != 200) {
+      throw new Exception('Failed to get username');
+    }
+
+    $body = json_decode($response->getBody(), true);
+    $this->username = $body['username'];
+    return $this->username;
+  }
+}

--- a/application/libraries/Discourse.php
+++ b/application/libraries/Discourse.php
@@ -3,6 +3,9 @@
 use GuzzleHttp\Client;
 
 class Discourse {
+  const COMMISSIONED_OFFICER_GROUP = 73; // TODO: These are vanilla IDs
+  const HONORABLY_DISCHARGED_GROUP = 80;
+
   private $client;
   private $username;
 
@@ -16,7 +19,8 @@ class Discourse {
       'headers' => [
         'Api-Key' => $api_key,
         'Api-Username' => $api_username
-      ]
+      ],
+      'http_errors' => false
     ]);
   }
 
@@ -26,12 +30,10 @@ class Discourse {
   }
 
   public function update_display_name($member_id) {
-    $this->load->model('member_model');
-
     $member = $this->get_member($member_id);
-    $username = $this->get_username($member['forum_member_id']);
+    $forum_user = $this->get_forum_user($member['forum_member_id']);
 
-    $path = "u/{$username}";
+    $path = "u/{$forum_user['username']}";
     $payload = ['name' => $member['short_name']];
     $response = $this->client->put($path, ['json' => $payload]);
 
@@ -52,9 +54,128 @@ class Discourse {
     }, $body['groups']);
   }
 
+  public function update_roles($member_id) {
+    $member = $this->get_member($member_id);
+    $expected_roles = $this->get_expected_roles($member_id);
+    $current_roles = $this->get_current_roles($member_id);
+
+    $roles_to_delete = array_diff($current_roles, $expected_roles);
+    array_walk($roles_to_delete, [$this, 'delete_role'], $member['forum_member_id']);
+
+    $roles_to_add = array_diff($expected_roles, $current_roles);
+    array_walk($roles_to_add, [$this, 'add_role'], $member['forum_member_id']);
+
+    return [
+      'forum_member_id' => $member['forum_member_id'],
+      'expected_roles' => $expected_roles,
+      'current_roles' => $current_roles,
+      'roles_to_delete' => $roles_to_delete,
+      'roles_to_add' => $roles_to_add
+    ];
+  }
+
+  private function get_expected_roles($member_id) {
+    $assignments = $this->get_assignments($member_id);
+    $class_roles = $this->get_class_roles_for_assignments($assignments);
+    $unit_roles = $this->get_unit_roles_for_assignments($assignments);
+    $expected_roles = array_filter(array_merge($class_roles, $unit_roles));
+
+    // TODO: Check whether this logic still makes sense in Discourse
+    // (is there a public member group?)
+    if (empty($assignments) && $this->is_honorably_discharged($member_id)) {
+        $expected_roles[] = self::HONORABLY_DISCHARGED_GROUP;
+    }
+
+    if (strpos($member['rank']['grade'], 0, 2) == 'O-') {
+      $expected_roles[] = self::COMMISSIONED_OFFICER_GROUP;
+    }
+
+    return $expected_roles;
+  }
+
+  private function get_current_roles($member_id) {
+    $member = $this->get_member($member_id);
+    $forum_user = $this->get_forum_user($member['forum_member_id']);
+
+    // Omits automatic roles, e.g. trust groups
+    function is_custom_role($role) {
+      return ! $role['automatic'];
+    }
+
+    return pluck('id', array_filter($forum_user['groups'], is_custom_role));
+  }
+
+  private function delete_role($role, $index, $member_id) {
+    error_log("Deleting role {$role} from member {$member_id}");
+    $path = "/admin/users/{$member_id}/groups/{$role}";
+    $response = $this->client->delete($path);
+
+    if ($response->getStatusCode() != 200) {
+      throw new Exception("Failed to delete role {$role} from member {$member_id}");
+    }
+  }
+
+  private function add_role($role, $index, $member_id) {
+    $path = "/admin/users/{$member_id}/groups";
+    $payload = ['group_id' => $role];
+    $response = $this->client->post($path, ['json' => $payload]);
+
+    if ($response->getStatusCode() != 200) {
+      throw new Exception("Failed to add role {$role} to member {$member_id}");
+    }
+  }
+
+  private function get_assignments($member_id) {
+    $this->load->model('assignment_model');
+
+    return nest($this->assignment_model
+      ->where('assignments.member_id', $member_id)
+      ->order_by('priority')
+      ->by_date()
+      ->get()
+      ->result_array());
+  }
+
+  private function get_class_roles_for_assignments($assignments) {
+    $this->load->model('class_role_model');
+
+    $classes = array_unique(array_map(function($row) {
+      return $row['unit']['class'];
+    }, $assignments));
+
+    return pluck('role_id', $this->class_role_model
+      ->by_classes($classes)
+      ->get()
+      ->result_array());
+  }
+
+  private function get_unit_roles_for_assignments($assignments) {
+    $this->load->model('unit_role_model');
+
+    $roles = [];
+    foreach($assignments as $assignment) {
+      $assignment_roles = pluck('role_id', $this->unit_role_model
+        ->by_unit($assignment['unit']['id'], $assignment['position']['access_level'])
+        ->get()
+        ->result_array());
+      if ( ! empty($assignment_roles)) {
+        $roles = array_merge($roles, $assignment_roles);
+      }
+    }
+    return $roles;
+  }
+
+  private function is_honorably_discharged($member_id) {
+    $this->load->model('discharge_model');
+
+    $discharges = $this->discharge_model->get()->result_array(); // sorted by date desc by default
+    return ($discharges && $discharge[0]['type'] == 'Honorable');
+  }
+
   private function get_member($member_id) {
     if ($this->member) return $this->member;
 
+    $this->load->model('member_model');
     $this->member = nest($this->member_model->get_by_id($member_id));
     if ( ! $this->member['forum_member_id']) {
       throw new Exception('Member has no forum_member_id');
@@ -63,8 +184,8 @@ class Discourse {
     return $this->member;
   }
 
-  private function get_username($forum_member_id) {
-    if ($this->username) return $this->username;
+  private function get_forum_user($forum_member_id) {
+    if ($this->forum_user) return $this->forum_user;
 
     $path = "/admin/users/{$forum_member_id}.json";
     $response = $this->client->get($path);
@@ -72,8 +193,7 @@ class Discourse {
       throw new Exception('Failed to get username');
     }
 
-    $body = json_decode($response->getBody(), true);
-    $this->username = $body['username'];
-    return $this->username;
+    $this->forum_user = json_decode($response->getBody(), true);
+    return $this->forum_user;
   }
 }

--- a/application/libraries/Discourse.php
+++ b/application/libraries/Discourse.php
@@ -40,6 +40,18 @@ class Discourse {
     }
   }
 
+  public function get_role_list() {
+    $response = $this->client->get('groups.json');
+    $body = json_decode($response->getBody(), true);
+
+    // Match key names of vanilla API
+    return array_map(function ($row) {
+      $row['roleID'] = $row['id'];
+      unset($row['id']);
+      return $row;
+    }, $body['groups']);
+  }
+
   private function get_member($member_id) {
     if ($this->member) return $this->member;
 

--- a/application/libraries/Forum.php
+++ b/application/libraries/Forum.php
@@ -1,0 +1,113 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Forum {
+  // Enables the use of CI super-global without having to define an extra variable
+  public function __get($var) {
+      return get_instance()->$var;
+  }
+
+  protected function get_expected_roles($member_id, $forum) {
+    $special_roles = $this->get_special_roles($member_id, $forum);
+    $unit_roles = $this->get_unit_roles($member_id, $forum);
+    $expected_roles = array_filter(array_merge($special_roles, $unit_roles));
+
+    return $expected_roles;
+  }
+
+  protected function get_special_roles($member_id, $forum) {
+    $special_attributes = ['everyone'];
+
+    if ($this->is_member($member_id)) {
+      $special_attributes[] = 'member';
+    }
+
+    if ($this->is_honorably_discharged($member_id)) {
+      $special_attributes[] = 'honorably_discharged';
+    }
+
+    if ($this->is_officer($member_id)) {
+      $special_attributes[] = 'officer';
+    }
+
+    $this->load->model('special_role_model');
+
+    return pluck('role_id', $this->special_role_model
+      ->by_special_attributes($special_attributes)
+      ->by_forum($forum)
+      ->get()
+      ->result_array());
+  }
+
+  protected function get_unit_roles($member_id, $forum) {
+    $assignments = $this->get_assignments($member_id);
+    $this->load->model('unit_role_model');
+
+    $roles = [];
+    foreach($assignments as $assignment) {
+      $assignment_roles = pluck('role_id', $this->unit_role_model
+        ->by_unit($assignment['unit']['id'], $assignment['position']['access_level'])
+        ->by_forum($forum)
+        ->get()
+        ->result_array());
+      if ( ! empty($assignment_roles)) {
+        $roles = array_merge($roles, $assignment_roles);
+      }
+    }
+    return $roles;
+  }
+
+  protected function get_assignments($member_id) {
+    $this->load->model('assignment_model');
+
+    return nest($this->assignment_model
+      ->where('assignments.member_id', $member_id)
+      ->order_by('priority')
+      ->by_date()
+      ->get()
+      ->result_array());
+  }
+
+  protected function is_member($member_id) {
+    $assignments = $this->get_assignments($member_id);
+
+    $assignment_classes = array_map(function($assignment) {
+      return $assignment['unit']['class'];
+    }, $assignments);
+
+    return in_array('Combat', $assignment_classes)
+      || in_array('Staff', $assignment_classes);
+  }
+
+  protected function is_honorably_discharged($member_id) {
+    $assignments = $this->get_assignments($member_id);
+
+    $this->load->model('discharge_model');
+    $discharges = $this->discharge_model
+      ->where('discharges.member_id', $member_id)
+      ->get()
+      ->result_array(); // sorted by date desc by default
+
+    return empty($assignments)
+      && sizeof($discharges) > 0
+      && $discharges[0]['type'] == 'Honorable';
+  }
+
+  protected function is_officer($member_id) {
+    $member = $this->get_member($member_id);
+
+    $officers = ['2Lt.', '1Lt.', 'Cpt.', 'Maj.', 'Lt. Col.', 'Col.'];
+    return in_array($member['rank']['abbr'], $officers);
+  }
+
+  protected function get_member($member_id) {
+    if ($this->member) return $this->member;
+
+    $this->load->model('member_model');
+    $this->member = nest($this->member_model->get_by_id($member_id));
+    if ( ! $this->member['forum_member_id']) {
+      throw new Exception('Member has no forum_member_id');
+    }
+
+    return $this->member;
+  }
+}

--- a/application/libraries/Vanilla.php
+++ b/application/libraries/Vanilla.php
@@ -3,6 +3,9 @@
 use GuzzleHttp\Client;
 
 class Vanilla {
+    const PUBLIC_MEMBER_GROUP = 8; // These are vanilla IDs
+    const COMMISSIONED_OFFICER_GROUP = 73;
+    const HONORABLY_DISCHARGED_GROUP = 80;
     
     private $vanilla_db;
     
@@ -66,19 +69,19 @@ class Vanilla {
         }
         
         //If not assigned anywhere let's check if member had been HDed
-        if (empty($roles) || $roles[0] == '8')
+        if (empty($roles) || $roles[0] == self::PUBLIC_MEMBER_GROUP)
         {
             $this->discharge_model->where('discharges.member_id',$member_id);
             $discharge = $this->discharge_model->get()->result_array();
             if ( $discharge && $discharge[0]['type'] == "Honorable")
-                $roles[] = '80';
+                $roles[] = self::HONORABLY_DISCHARGED_GROUP;
         }
         
         //Adding for officers
         $rank = $member['rank']['abbr'];
         if( $rank == '2Lt.' || $rank == '1Lt.' || $rank == 'Cpt.' || $rank == 'Maj.' || $rank == 'Lt. Col.' || $rank == 'Col.' )
         {
-            $roles[] = '73';//$this->get_commisioned_officer_role_id();
+            $roles[] = self::COMMISSIONED_OFFICER_GROUP;//$this->get_commisioned_officer_role_id();
         }
 
         // Eliminate duplicates

--- a/application/libraries/Vanilla.php
+++ b/application/libraries/Vanilla.php
@@ -98,7 +98,7 @@ class Vanilla {
     /**
      * Find the steam id associated with the forum member account if it exists
      */
-    public function update_username($member_id) {
+    public function update_display_name($member_id) {
         $this->load->model('member_model');
         
         // Get member info

--- a/application/models/special_role_model.php
+++ b/application/models/special_role_model.php
@@ -1,0 +1,14 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+class Special_Role_model extends MY_Model {
+    public $table = 'special_roles';
+    public $primary_key = 'special_roles.id';
+
+    public function by_forum($forum) {
+      return $this->filter_where('special_roles.forum_id', $forum);
+    }
+    
+    public function by_special_attributes($attributes) {
+        return $this->filter_where_in('special_roles.special_attribute', $attributes);
+    }
+}

--- a/application/models/unit_role_model.php
+++ b/application/models/unit_role_model.php
@@ -3,6 +3,10 @@
 class Unit_Role_model extends MY_Model {
     public $table = 'unit_roles';
     public $primary_key = 'unit_roles.id';
+
+    public function by_forum($forum) {
+      return $this->filter_where('unit_roles.forum_id', $forum);
+    }
     
     public function by_unit($unit_id, $access_level = FALSE) {
         $this->filter_where('unit_roles.unit_id', $unit_id);


### PR DESCRIPTION
- Creates `Forum` base class for `Vanilla` library, and moves "expected roles" logic to it
- Adds `Discourse` library that also extends `Forum`
- Replaces `class_roles` with `special_roles`
- Renames `update_username` to `update_display_name` throughout codebase