### PR TITLE
Dual running forums

### DIFF
--- a/application/controllers/users.php
+++ b/application/controllers/users.php
@@ -85,7 +85,6 @@ class Users extends MY_Controller {
         }
     }*/
 
-    // TODO: enforce unique constraint on members.discourse_member_id if not already
     public function associate_post() {
         $discourse_session = $this->user->get_discourse_session();
 

--- a/application/controllers/users.php
+++ b/application/controllers/users.php
@@ -57,7 +57,8 @@ class Users extends MY_Controller {
         }
     }
 
-    public function associate_post() {
+    // Post-transition associate method
+    /*public function associate_post() {
         if( ! $forum_member_id = $this->user->logged_in()) {
             $this->response(array('status' => false, 'error' => 'Not logged in'), 401);
         } elseif ($this->user->member('id')) {
@@ -81,6 +82,30 @@ class Users extends MY_Controller {
 
                 $this->response(array('status' => true, 'member' => $member));
             }
+        }
+    }*/
+
+    // TODO: enforce unique constraint on members.discourse_member_id if not already
+    public function associate_post() {
+        $discourse_session = $this->user->get_discourse_session();
+
+        if( ! $discourse_session) {
+            $this->response(array('status' => false, 'error' => 'Not logged in to discourse'), 401);
+        } elseif ( ! $this->user->logged_in()) {
+            $this->response(array('status' => false, 'error' => 'Not logged in to vanilla'), 401);
+        } elseif ($this->user->member('discourse_forum_member_id')) {
+            $this->response(array('status' => false, 'error' => 'Already associated'));
+        } else {
+            $personnel_member_id = $this->user->member('id');
+            $discourse_member_id = $discourse_session['id'];
+
+            $this->member_model->save($personnel_member_id, array('discourse_forum_member_id' => $discourse_member_id));
+
+            // update both forums
+            $this->forums->update_display_name($personnel_member_id);
+            $this->forums->update_roles($personnel_member_id);
+
+            $this->response(array('status' => true));
         }
     }
 }

--- a/application/core/MY_Controller.php
+++ b/application/core/MY_Controller.php
@@ -16,7 +16,7 @@ class MY_Controller extends REST_Controller {
         // Load user library and pass it third-party (forum) cookie
         $this->load->library('user', array('cookie' => $this->input->cookie(config_item('third_party_cookie'))));
 
-        $this->load->library(getenv('FORUMS_LIBRARY_CLASS') ?: 'vanilla', '', 'forums');
+        $this->load->library('all_forums', '', 'forums');
     }
 
     // Standard GET index allowing filtering by member and unit. Common across many controllers.

--- a/application/libraries/All_Forums.php
+++ b/application/libraries/All_Forums.php
@@ -1,0 +1,20 @@
+<?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
+
+require_once('Vanilla.php');
+
+class All_Forums extends Vanilla {
+  public function __construct() {
+    parent::__construct();
+    $this->load->library('discourse');
+  }
+
+  public function update_display_name($member_id) {
+    $this->discourse->update_display_name($member_id);
+    return parent::update_display_name($member_id);
+  }
+
+  public function update_roles($member_id) {
+    $this->discourse->update_roles($member_id);
+    return parent::update_roles($member_id);
+  }
+}

--- a/application/libraries/All_Forums.php
+++ b/application/libraries/All_Forums.php
@@ -9,12 +9,20 @@ class All_Forums extends Vanilla {
   }
 
   public function update_display_name($member_id) {
-    $this->discourse->update_display_name($member_id);
+    try {
+      $this->discourse->update_display_name($member_id);
+    } catch (NoLinkedForumAccountException $e) {
+      error_log($e->getMessage());
+    } 
     return parent::update_display_name($member_id);
   }
 
   public function update_roles($member_id) {
-    $this->discourse->update_roles($member_id);
+    try {
+      $this->discourse->update_roles($member_id);
+    } catch (NoLinkedForumAccountException $e) {
+      error_log($e->getMessage());
+    }
     return parent::update_roles($member_id);
   }
 }

--- a/application/libraries/Forum.php
+++ b/application/libraries/Forum.php
@@ -1,5 +1,7 @@
 <?php if ( ! defined('BASEPATH')) exit('No direct script access allowed');
 
+class NoLinkedForumAccountException extends Exception {}
+
 class Forum {
   // Enables the use of CI super-global without having to define an extra variable
   public function __get($var) {
@@ -104,8 +106,8 @@ class Forum {
 
     $this->load->model('member_model');
     $this->member = nest($this->member_model->get_by_id($member_id));
-    if ( ! $this->member['forum_member_id']) {
-      throw new Exception("Member {$member_id} has no forum_member_id");
+    if ( ! $this->member[$this->member_id_key]) {
+      throw new NoLinkedForumAccountException("Member {$member_id} has no {$this->member_id_key}");
     }
 
     return $this->member;

--- a/application/libraries/Forums_Cookie.php
+++ b/application/libraries/Forums_Cookie.php
@@ -9,9 +9,9 @@ class Forums_Cookie {
   private $SecretKey;
   private $ForumsUser;
 
-  public function __construct() {
-    $this->CookieName = getenv('FORUMS_COOKIE_NAME');
-    $this->SecretKey = getenv('FORUMS_SECRET_KEY');
+  public function __construct($params) {
+    $this->CookieName = $params['cookie_name'];
+    $this->SecretKey = $params['secret_key'];
 
     if (empty($this->CookieName)) {
       throw new Exception('Forums cookie name is empty.', 500);

--- a/application/libraries/User.php
+++ b/application/libraries/User.php
@@ -14,12 +14,17 @@ class User {
     
     public function __construct($params) {
         //if(isset($params['cookie'])) $this->cookie = $params['cookie'];
-
         $vanilla_params = [
             'cookie_name' => getenv('VANILLA_COOKIE_NAME'),
             'secret_key' => getenv('VANILLA_SECRET_KEY')
         ];
         $this->load->library('Forums_Cookie', $vanilla_params);
+
+        $discourse_params = [
+            'cookie_name' => getenv('DISCOURSE_COOKIE_NAME'),
+            'secret_key' => getenv('DISCOURSE_SECRET_KEY')
+        ];
+        $this->load->library('Forums_Cookie', $discourse_params, 'discourse_cookie');
     }
     
     /**
@@ -66,6 +71,14 @@ class User {
             return FALSE;
         }
         
+    }
+
+    public function get_discourse_session() {
+        if( ! isset($this->discourse_session)) {
+            $this->discourse_session = $this->discourse_cookie->getForumsUser();
+        }
+        
+        return $this->discourse_session;
     }
 
     public function has_admin_key() {

--- a/application/libraries/User.php
+++ b/application/libraries/User.php
@@ -14,7 +14,12 @@ class User {
     
     public function __construct($params) {
         //if(isset($params['cookie'])) $this->cookie = $params['cookie'];
-        $this->load->library('Forums_Cookie');
+
+        $vanilla_params = [
+            'cookie_name' => getenv('VANILLA_COOKIE_NAME'),
+            'secret_key' => getenv('VANILLA_SECRET_KEY')
+        ];
+        $this->load->library('Forums_Cookie', $vanilla_params);
     }
     
     /**

--- a/application/libraries/User.php
+++ b/application/libraries/User.php
@@ -53,26 +53,6 @@ class User {
         // If we've already done this, return the user id
         if(isset($this->forum_member_id)) return $this->forum_member_id;
         
-        // Otherwise, check if third-party (forum) cookie is set
-        /*if($this->cookie) {
-            // Parse cookie
-            list($user_id, $password) = unserialize($this->cookie);
-            //$user_id = 6804; // DEBUG
-            //$user_id = 81683; // DEBUG Non-existent member id
-            //$user_id = 6; // Retired member
-            // Verify user_id & password from cookie against forum DB
-            if($this->authenticate($user_id, $password)) {
-                // Verified - save the user_id of the user
-                $this->forum_member_id = $user_id;
-                return $this->forum_member_id;
-            } else {
-                // Didn't verify
-                return FALSE;
-            }
-        } else {
-            // No cookie set
-            return FALSE;
-        }*/
         if($user = $this->forums_cookie->getForumsUser()) {
             $this->forum_member_id = $user['id'];
             $this->forum_email = $user['email'];

--- a/application/libraries/Vanilla.php
+++ b/application/libraries/Vanilla.php
@@ -4,6 +4,8 @@ require_once('Forum.php');
 use GuzzleHttp\Client;
 
 class Vanilla extends Forum {
+    public $member_id_key = 'forum_member_id';
+
     private $vanilla_db;
     
     public function __construct() {
@@ -20,7 +22,7 @@ class Vanilla extends Forum {
         $expected_roles = $this->get_expected_roles($member_id, 'vanilla');
 
         if (!empty($expected_roles)) {
-            $path = "users/{$member['forum_member_id']}";
+            $path = "users/{$member[$this->member_id_key]}";
             $payload = ['roleID' => $expected_roles];
             $response = $this->client->patch($path, ['json' => $payload]);
 
@@ -30,7 +32,7 @@ class Vanilla extends Forum {
         }
 
         return [
-            'forum_member_id' => $member['forum_member_id'],
+            'forum_member_id' => $member[$this->member_id_key],
             'expected_roles' => $expected_roles
         ];
     }
@@ -45,7 +47,7 @@ class Vanilla extends Forum {
         $member = nest($this->member_model->get_by_id($member_id));
 
         // If no forum_member_id, there's nothing to do
-        if( ! $member['forum_member_id']) {
+        if( ! $member[$this->member_id_key]) {
             //$this->response(array('status' => false, 'error' => 'Member does not have a corresponding forum user id'), 400);
             return FALSE;
         }
@@ -66,7 +68,7 @@ class Vanilla extends Forum {
             
         }
         
-        $path = 'users/' . $member['forum_member_id'];
+        $path = 'users/' . $member[$this->member_id_key];
         $data = [ 'name' => $newMemberName ];
         $response = $this->client->patch($path, [ 'json' => $data ]);
         if ($response->getStatusCode() != 200) {
@@ -77,7 +79,7 @@ class Vanilla extends Forum {
     
     public function get_steam_id($member_id) {
         $member = $this->get_member($member_id);
-        $user_id = $member['forum_member_id'];
+        $user_id = $member[$this->member_id_key];
         return str_replace( 'https://steamcommunity.com/openid/id/', '', $this->vanilla_db->query('SELECT `Value` FROM `GDN_UserMeta` WHERE `Name` = \'Plugin.steamprofile.SteamID64\' AND `UserID` = ' . (int) $user_id)->row_array());
     }
     
@@ -88,7 +90,7 @@ class Vanilla extends Forum {
 
     public function get_user_ip($member_id) {
         $member = $this->get_member($member_id);
-        $forum_member_id = $member['forum_member_id'];
+        $forum_member_id = $member[$this->member_id_key];
         $res = $this->vanilla_db->query('SELECT `AllIPAddresses` FROM GDN_User WHERE `UserID` = ' . (int) $forum_member_id)->row_array();
         
         $arr = ( isset( $res['AllIPAddresses'] ) ? explode( ',', $res['AllIPAddresses'] ) : [] );
@@ -106,7 +108,7 @@ class Vanilla extends Forum {
 
     public function get_user_email($member_id) {
         $member = $this->get_member($member_id);
-        $forum_member_id = $member['forum_member_id'];
+        $forum_member_id = $member[$this->member_id_key];
         $response = $this->client->get('users/' . $forum_member_id);
         $data = json_decode($response->getBody(), true);
         return $data['email'];
@@ -114,7 +116,7 @@ class Vanilla extends Forum {
 
     public function get_user_bday($member_id) {
         $member = $this->get_member($member_id);
-        $forum_member_id = $member['forum_member_id'];
+        $forum_member_id = $member[$this->member_id_key];
         $res = $this->vanilla_db->query('SELECT `DateOfBirth` FROM GDN_User WHERE `UserID` = ' . (int) $forum_member_id)->row_array();
         return ( $res ? $res['DateOfBirth'] : '' );
     }

--- a/application/models/member_model.php
+++ b/application/models/member_model.php
@@ -66,7 +66,7 @@ class Member_model extends MY_Model {
     }
     
     public function default_select() {
-        $this->db->select('members.id, members.last_name, members.first_name, members.middle_name, members.name_prefix, members.steam_id, members.city, members.forum_member_id')
+        $this->db->select('members.id, members.last_name, members.first_name, members.middle_name, members.name_prefix, members.steam_id, members.city, members.forum_member_id, members.discourse_forum_member_id')
             ->select($this->virtual_fields['short_name'] . ' AS short_name, ' . $this->virtual_fields['full_name'] . ' AS full_name', FALSE)
             ->select('members.rank_id AS `rank|id`, ranks.abbr AS `rank|abbr`, ranks.name AS `rank|name`, ranks.filename AS `rank|filename`')
             ->select('units.id AS `unit|id`, units.abbr AS `unit|abbr`, ' . $this->virtual_fields['unit_key'] . ' AS `unit|key`, units.name AS `unit|name`, ' . $this->virtual_fields['depth'] . ' AS `unit|depth`, units.path AS `unit|path` ', FALSE)


### PR DESCRIPTION
Allow users to associate their personnel account with their discourse account, and have personnel update both vanilla and discourse, if the latter is associated.